### PR TITLE
Add an enabled flag for per environment usage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ module.exports = {
   createDeployPlugin: function(options) {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
-      requiredConfig: ['webhookURL'],
       defaultConfig: {
+        enabled: true,
+
         willDeploy: function(context) {
           return function(slack){
             return {
@@ -126,8 +127,9 @@ module.exports = {
       },
       _initSlackNotifier: function() {
         var webhookURL = this.readConfig('webhookURL');
+        var enabled  = !!this.readConfig('enabled');
 
-        if (!webhookURL) {
+        if (!webhookURL && enabled) {
           var message   = 'Ember-CLI-Deploy: You have to pass a `webhookURL` config-option to ember-cli-deploy-slack';
           throw new Error(message);
         }
@@ -136,6 +138,7 @@ module.exports = {
         var username  = this.readConfig('username');
 
         return this.readConfig('slackNotifier') || new SlackNotifier({
+          enabled: enabled,
           webhookURL: webhookURL,
           channel: channel,
           username: username

--- a/lib/slack-notifier.js
+++ b/lib/slack-notifier.js
@@ -13,11 +13,15 @@ module.exports = CoreObject.extend({
 
     this.notify = function(message) {
       return new Promise(function(resolve, reject) {
-        this.slack.notify(message, function(error, result) {
-          if (error) { return reject(error); }
+        if (this.enabled) {
+          this.slack.notify(message, function(error, result) {
+            if (error) { return reject(error); }
 
-          return resolve(result);
-        });
+            return resolve(result);
+          });
+        } else {
+          return resolve();
+        }
       }.bind(this));
     }
   }

--- a/node-tests/unit/index-test.js
+++ b/node-tests/unit/index-test.js
@@ -82,8 +82,9 @@ describe('the index', function() {
       };
 
       plugin.beforeHook(context);
+      plugin.configure(context);
       assert.throws(function(){
-        plugin.configure(context);
+        plugin.didDeploy(context);
       })
     });
 
@@ -113,7 +114,7 @@ describe('the index', function() {
 
         return previous;
       }, []);
-      assert.equal(messages.length, 3);
+      assert.equal(messages.length, 4);
     });
 
     it('adds default config to the config object', function() {

--- a/node-tests/unit/slack-test.js
+++ b/node-tests/unit/slack-test.js
@@ -16,6 +16,7 @@ describe('SlackNotifier', function() {
 
   beforeEach(function() {
     slack = new SlackNotifier({
+      enabled: true,
       webhookURL: WEBHOOK_URL,
       channel: CHANNEL,
       username: USER_NAME
@@ -31,35 +32,58 @@ describe('SlackNotifier', function() {
 
   it('it can be initialized', function() {
     expect(slack).to.be.ok;
+    expect(slack.enabled).to.eql(true);
     expect(slack.webhookURL).to.eql(WEBHOOK_URL);
     expect(slack.channel).to.eql(CHANNEL);
     expect(slack.username).to.eql(USER_NAME);
   });
 
-  describe('#notify', function() {
-    it('is callable', function() {
-      expect(typeof(slack.notify)).to.eql('function');
+  describe('enabled', function() {
+    describe('#notify', function() {
+      it('is callable', function() {
+        expect(typeof(slack.notify)).to.eql('function');
+      });
+
+      it('sends the correct params to the node-slackr library', function() {
+        var messages = {
+            text: "using node-slackr to send messages to slack"
+        };
+
+        slack.notify(messages);
+
+        expect(slackNotify.calledWith(messages)).to.be.ok;
+      });
+
+      it('returns a promise', function() {
+        var messages = {
+            text: "I can haz promises instead of callbacks"
+        };
+
+        expect(slack.notify(messages).then).to.be.ok;
+        expect(slack.notify(messages).catch).to.be.ok;
+      });
+    });
+  });
+
+  describe('disabled', function() {
+    beforeEach(function() {
+      slack = new SlackNotifier({
+        enabled: false,
+        webhookURL: WEBHOOK_URL,
+        channel: CHANNEL,
+        username: USER_NAME
+      });
     });
 
-    it('sends the correct params to the node-slackr library', function() {
-      var messages = {
-          text: "using node-slackr to send messages to slack"
-      };
+    describe('#notify', function() {
+      it('is callable', function() {
+        expect(typeof(slack.notify)).to.eql('function');
+      });
 
-      slack.notify(messages);
-
-      expect(slackNotify.calledWith(messages)).to.be.ok;
+      it('returns a promise', function() {
+        expect(slack.notify({}).then).to.be.ok;
+        expect(slack.notify({}).catch).to.be.ok;
+      });
     });
-
-    it('returns a promise', function() {
-      var messages = {
-          text: "I can haz promises instead of callbacks"
-      };
-
-      expect(slack.notify(messages).then).to.be.ok;
-      expect(slack.notify(messages).catch).to.be.ok;
-    });
-
-
   });
 })


### PR DESCRIPTION
Thanks for all the work on this! Currently, slack-notifier must be turned on and notifying in all environments. This adds an `enabled` flag, with a default of true, so that notifications can be turned off in specific environments.

This removes the requirement for specifying a webhookurl but makes the error throwing later conditional on the enabled flag.
