### PR TITLE
[DOC] fix broken links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ to see how you can customize your messages.
 
 - `npm test`
 
-[2]: http://ember-cli.github.io/ember-cli-deploy/plugins "Plugin Documentation"
+[2]: http://ember-cli-deploy.com/docs/v0.6.x/plugins-overview/ "Plugin Documentation"


### PR DESCRIPTION
## What Changed & Why

@ghedamat mentioned using
http://ember-cli-deploy.github.io/ember-cli-deploy/docs/v0.6.x/configuration-overview/ but I think http://ember-cli-deploy.com/docs/v0.6.x/plugins-overview/ would be more appropriate?
If not, let me know and I can switch the URL
## Related issues

resolves #14 
## PR Checklist
- [ ] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]
## People

@ghedamat
