### PR TITLE
Replace deprecated `ember-cli/ext/promise` with `rsvp`

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -13,11 +13,11 @@
 
 var EOL       = require('os').EOL;
 var multiline = require('multiline');
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP      = require('rsvp');
 var GitHubApi = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = 'v' + require('../package').version;
 
 var user = 'ember-cli-deploy';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var Promise       = require('ember-cli/lib/ext/promise');
 var SilentError   = require('silent-error');
 var SlackNotifier = require('./lib/slack-notifier');
 var DeployPluginBase = require('ember-cli-deploy-plugin');

--- a/lib/slack-notifier.js
+++ b/lib/slack-notifier.js
@@ -1,4 +1,4 @@
-var Promise    = require('ember-cli/lib/ext/promise');
+var RSVP       = require('rsvp');
 var CoreObject = require('core-object');
 var Slack      = require ('node-slackr');
 
@@ -9,7 +9,7 @@ module.exports = CoreObject.extend({
     this.slack = new Slack(this.webhookURL, this._getSlackOptions());
 
     this.notify = function(message) {
-      return new Promise(function(resolve, reject) {
+      return new RSVP.Promise(function(resolve, reject) {
         if (this.enabled) {
           this.slack.notify(message, function(error, result) {
             if (error) { return reject(error); }

--- a/node-tests/unit/index-test.js
+++ b/node-tests/unit/index-test.js
@@ -1,5 +1,5 @@
 'use strict';
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP   = require('rsvp');
 var assert = require('ember-cli/tests/helpers/assert');
 
 var WEBHOOK_URL = 'https://hooks.slack.com/services/123123';
@@ -156,7 +156,7 @@ describe('the index', function() {
             slackNotifier: {
               notify: function(message){
                 slackMessages.push(message);
-                return Promise.resolve();
+                return RSVP.resolve();
               }
             }
           }

--- a/node-tests/unit/slack-test.js
+++ b/node-tests/unit/slack-test.js
@@ -1,8 +1,7 @@
 var expect        = require('chai').expect;
 var sinon         = require('sinon');
-var Slack = require('node-slackr');
+var Slack         = require('node-slackr');
 var SlackNotifier = require('../../lib/slack-notifier.js');
-var Promise    = require('ember-cli/lib/ext/promise');
 
 var WEBHOOK_URL = 'https://hooks.slack.com/services/123123';
 var CHANNEL     = '#testing';

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-cli-deploy-plugin": "^0.2.1",
     "moment": "^2.17.1",
     "node-slackr": "^0.1.0",
+    "rsvp": "^3.4.0",
     "silent-error": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
## What Changed & Why
Replaced deprecated ember-cli/ext/promise with rsvp. Ember CLI 2.12 Beta complains about this deprecation.