### PR TITLE
Upgrade node-slackr to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-slack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An ember-cli-deploy-plugin for sending messages to Slack",
   "directories": {
     "doc": "doc",
@@ -36,7 +36,7 @@
     "core-object": "^2.0.0",
     "ember-cli-deploy-plugin": "^0.2.3",
     "moment": "^2.17.1",
-    "node-slackr": "^0.1.0",
+    "node-slackr": "^0.2.0",
     "rsvp": "^3.5.0",
     "silent-error": "^1.0.0"
   },


### PR DESCRIPTION
## What Changed & Why
Upgrade `node-slackr` to version `0.2.0` which removes deprecation warnings.